### PR TITLE
[🐸 Frogbot] Update version of axios to 1.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.3.4",
+        "axios": "^1.7.4",
         "cookie-parser": "~1.4.4",
         "crypto-browserify": "3.12.0",
         "debug": "~2.6.9",
@@ -409,9 +409,10 @@
       "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g=="
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://soleng.jfrog.io/artifactory/api/npm/frogs-npm-dev-virtual/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/rkfrog/demo-node-app#readme",
   "dependencies": {
-    "axios": "^1.3.4",
+    "axios": "^1.7.4",
     "cookie-parser": "~1.4.4",
     "crypto-browserify": "3.12.0",
     "debug": "~2.6.9",
@@ -41,6 +41,8 @@
     "http-errors": "~1.6.3",
     "lodash": "4.17.0",
     "minimatch": "~3.0.4",
+    "mocha": "7.0.0",
+    "moment": "1.2.0",
     "morgan": "~1.9.1",
     "next": "13.5.4",
     "node-emoji": "^2.1.0",
@@ -50,10 +52,8 @@
     "process": "0.11.10",
     "react": "18",
     "react-dom": "18",
+    "socket.io": "1.4.3",
     "stream-browserify": "3.0.0",
-    "word-wrap": "^1.2.5",
-    "moment": "1.2.0",
-    "mocha": "7.0.0",
-    "socket.io": "1.4.3"
+    "word-wrap": "^1.2.5"
   }
 }


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>


## 📦 Vulnerable Dependencies

### ✍️ Summary
<div align='center'>

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                  | FIXED VERSIONS                  | CVES                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/notApplicableHigh.png)<br>    High | Not Applicable | axios:1.7.2 | axios 1.7.2 | [1.7.4] | CVE-2024-39338 |

</div>


### 🔬 Research Details


**Description:**
Axios is a promise-based HTTP Client for Node.js and the browser.

A protocol relative URL is a link to a URL that does not specify the scheme (e.g. `//example.com`). The scheme used in the request is dependent on the site where the URL is linked from. For example, if a user browses to `https://examplesite.com` and clicks a link to the URL `//example.com`, a request would be sent to `https://example.com`. 

It has been discovered that Axios is vulnerable to SSRF caused by unexpected behavior where requests for path relative URLs get processed as protocol relative URLs. 
For example, a server might want to invoke a request for a path relative to the base URL, based on user input (e.g. `http://example.com/1234`). The developer can do so by using the following code:
```
this.axios = axios.create({
  baseURL: 'http://example.com',
});

// User input
userId = '1234';

this.axios.get(`/${userId}`).then(...);
```

Note that when the `axios.get()` function receives a path-relative URL as an argument, it prepends it with `baseURL` to make it absolute. However, protocol-relative URLs are considered absolute by Axios, which means they aren't prepended with `baseURL`.
Thus, by supplying the input `/malicious.com`, an attacker can cause the server to invoke a request for `http://malicious.com`. This is contrary to the expected behavior, of a request for `http://example.com//malicious.com`.

By utilizing this vulnerability, an attacker can make a server invoke requests for arbitrary domain names - also known as an SSRF attack.

**Remediation:**
##### Development mitigations

This vulnerability can be mitigated in a few ways:
1. Do not use path-relative URLs that begin with user input. Instead, make them absolute.
2. Make sure the user input supplied to a path-relative URL (e.g. `/${input}`) does not start with a slash.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
