### PR TITLE
[🐸 Frogbot] Update version of lodash to 4.17.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "3.3.7",
         "helmet": "^7.0.0",
         "http-errors": "~1.6.3",
-        "lodash": "4.17.0",
+        "lodash": "^4.17.21",
         "minimatch": "~3.0.4",
         "mocha": "7.0.0",
         "moment": "1.2.0",
@@ -2383,9 +2383,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.0",
-      "resolved": "https://soleng.jfrog.io/artifactory/api/npm/frogs-npm-dev-virtual/lodash/-/lodash-4.17.0.tgz",
-      "integrity": "sha512-wXJoUnY8v5rCurNIL6tM0TOv/F6B2NzDzLzStNOQoX/i88s8hPGkYSRPMtcdjORIx1dHUB1lQVhsNyC9yjD/7w=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "2.2.0",
@@ -4415,11 +4416,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/yargs-unparser/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://soleng.jfrog.io/artifactory/api/npm/frogs-npm-dev-virtual/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/yargs/node_modules/ansi-regex": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,10 @@
     "express": "3.3.7",
     "helmet": "^7.0.0",
     "http-errors": "~1.6.3",
-    "lodash": "4.17.0",
+    "lodash": "^4.17.21",
     "minimatch": "~3.0.4",
+    "mocha": "7.0.0",
+    "moment": "1.2.0",
     "morgan": "~1.9.1",
     "next": "13.5.4",
     "node-emoji": "^2.1.0",
@@ -50,10 +52,8 @@
     "process": "0.11.10",
     "react": "18",
     "react-dom": "18",
+    "socket.io": "1.4.3",
     "stream-browserify": "3.0.0",
-    "word-wrap": "^1.2.5",
-    "moment": "1.2.0",
-    "mocha": "7.0.0",
-    "socket.io": "1.4.3"
+    "word-wrap": "^1.2.5"
   }
 }


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>


## 📦 Vulnerable Dependencies

### ✍️ Summary
<div align='center'>

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                  | FIXED VERSIONS                  | CVES                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | Not Covered | lodash:4.17.0 | lodash 4.17.0 | [4.17.11] | CVE-2019-1010266 |

</div>


### 🔬 Research Details


**Description:**
lodash prior to 4.17.11 is affected by: CWE-400: Uncontrolled Resource Consumption. The impact is: Denial of service. The component is: Date handler. The attack vector is: Attacker provides very long strings, which the library attempts to match using a regular expression. The fixed version is: 4.17.11.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
